### PR TITLE
Improve syntax highlighting, fix #14

### DIFF
--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -21,33 +21,38 @@ if exists('s:current_syntax')
   let b:current_syntax = s:current_syntax
 endif
 
-"  <tag></tag>
-" s~~~~~~~~~~~e
-syntax region jsxRegion
-      \ start=+<\z([^ /!?<>="':]\+\)+
-      \ skip=+<!--\_.\{-}-->+
-      \ end=+</\z1\_\s\{-}[^(=>)]>+
-      \ end=+>\n\?\s*)\@=+
-      \ end=+>\n\?\s*}\@=+
-      \ end=+>;\@=+
-      \ end=+\n\?\s\*,+
-      \ end=+\s*>,\@=+
-      \ end=+\s\+:\@=+
-      \ fold
-      \ contains=jsxCloseString,jsxCloseTag,jsxTag,jsxComment,jsFuncBlock,
-                \@Spell
+" <tag id="sample">
+" s~~~~~~~~~~~~~~~e
+" and self close tag
+" <tag id="sample"   />
+" s~~~~~~~~~~~~~~~~~e
+syntax region jsxTag
+      \ start=+<\([^ /!?<>="':]\+\)\@=+
+      \ skip=+</[^ /!?<>"']\+>+
+      \ end=+/\@<!>+
+      \ end=+\(/>\)\@=+
+      \ contained
+      \ contains=jsxTag,jsxError,jsxTagName,jsxAttrib,jsxEqual,jsxString,jsxEscapeJs,
+                \jsxCloseString
       \ keepend
       \ extend
 
-" <tag id="sample">
-" s~~~~~~~~~~~~~~~e
-syntax region jsxTag
-      \ start=+<[^ /!?<>"':]\@=+
-      \ end=+>+
-      \ matchgroup=jsxCloseTag end=+/>+
-      \ contained
-      \ contains=jsxError,jsxTagName,jsxAttrib,jsxEqual,jsxString,jsxEscapeJs,
-                \jsxCloseString
+
+" <tag></tag>
+" s~~~~~~~~~e
+" and self close tag
+" <tag/>
+" s~~~~e
+syntax region jsxRegion
+      \ start=+<\z([^ /!?<>="':]\+\)+
+      \ skip=+<!--\_.\{-}-->+
+      \ end=+</\z1>+
+      \ end=+/>+
+      \ fold
+      \ contains=jsxRegion,jsxCloseString,jsxCloseTag,jsxTag,jsxComment,jsFuncBlock,
+                \@Spell
+      \ keepend
+      \ extend
 
 " </tag>
 " ~~~~~~

--- a/sample.js
+++ b/sample.js
@@ -1,3 +1,22 @@
+class App extends Component {
+  render() {
+    // NOTCE: no `;` after.
+    const arr = <div></div>
+
+    // Codes highlight incorrectly
+    var foo = 'foo';
+    if (foo === 'foo') {
+      console.log('hello');
+    }
+
+    var el = a < 0
+      ? <div></div>
+      : <a></a>
+
+    var b = el || <div>hello, world</div>
+  }
+}
+
 class Hoge extends React.Component {
   constructor(props) {
     super(props);


### PR DESCRIPTION
Changes:

- Improved `jsxRegion` group, the origin group is a bit of tricky.
- Moved `jsxTag` group before `jsxRegion`, or it will break.
- Added some test cases.

Tested on `sample.js` and my local projects, it works well.