### PR TITLE
Fix jsx attribute followed by `>` highlight error

### DIFF
--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -83,7 +83,7 @@ syntax match jsxTagName
 " <tag key={this.props.key}>
 "      ~~~
 syntax match jsxAttrib
-    \ +[-'"<]\@<!\<[a-zA-Z:_][-.0-9a-zA-Z0-9:_]*\>\(['">]\@!\|$\)+
+    \ +[-'"<]\@<!\<[a-zA-Z:_][-.0-9a-zA-Z0-9:_]*\>\(['"]\@!\|$\)+
     \ contained
     \ contains=jsxAttribPunct,jsxAttribHook
     \ display

--- a/sample.js
+++ b/sample.js
@@ -44,7 +44,7 @@ class Hoge extends React.Component {
 
   hoge() {
     Hoge.poge(
-      <div>
+      <div disabled>
         <div></div>
         {this.hoge}
         <div></div>


### PR DESCRIPTION
Before:

![image](https://cloud.githubusercontent.com/assets/3297602/25465056/a011d7c6-2b32-11e7-9669-eabdf2f253c7.png)

After:

![image](https://cloud.githubusercontent.com/assets/3297602/25465070/b231f828-2b32-11e7-8bf3-62aef952537f.png)
