### PR TITLE
Fix syntax like `arr[0] < num` highlight error

### DIFF
--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -45,7 +45,7 @@ syntax region jsxTag
 " s~~~~e
 " A big start regexp borrowed from https://git.io/vDyxc
 syntax region jsxRegion
-      \ start=+\(\((\|{\|}\|\[\|\]\|,\|&&\|||\|?\|:\|=\|=>\|\Wreturn\|^return\|\Wdefault\|^\|>\)\_s*\)\@<=<\_s*\z([_\$a-zA-Z]\(\.\?[\$0-9a-zA-Z]\+\)*\)+
+      \ start=+\(\((\|{\|}\|\[\|,\|&&\|||\|?\|:\|=\|=>\|\Wreturn\|^return\|\Wdefault\|^\|>\)\_s*\)\@<=<\_s*\z([_\$a-zA-Z]\(\.\?[\$0-9a-zA-Z]\+\)*\)+
       \ skip=+<!--\_.\{-}-->+
       \ end=+</\_s*\z1>+
       \ end=+/>+

--- a/sample.js
+++ b/sample.js
@@ -16,6 +16,7 @@ class App extends Component {
     var c = a<foo
     var d = a<foo
     var e = a>c
+    var bar = arr[1] < foo;
 
     if (a<b && a<d || a>c){
       return <a></a>


### PR DESCRIPTION
Syntax like `arr[0] < num` was not highlight correctly. This pr fixed this by remove `\]` in the start regexp.

But there still some rare edge case was not highlight correctly:

```jsx
<div>
  <div></div>[<div></div>]<div></div>
</div>
```