### PR TITLE
Improve scroll speed

### DIFF
--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -78,12 +78,13 @@ syntax match jsxEntityPunct contained "[&.;]"
 syntax match jsxTagName
     \ +<\_s*\zs[^/!?<>"']\++
     \ contained
+    \ nextgroup=jsxAttrib
     \ display
 
 " <tag key={this.props.key}>
 "      ~~~
 syntax match jsxAttrib
-    \ +\(\(<\_s*\)\@<!\_s\)\@<=\<[a-zA-Z_][-0-9a-zA-Z_]*\>\(\_s\+\|\_s*[=/>]\)\@=+
+    \ +\_s\<[a-zA-Z_][-0-9a-zA-Z_]*\>\(\_s\+\|\_s*[=/>]\)\@=+
     \ contained
     \ display
 

--- a/after/syntax/typescript.vim
+++ b/after/syntax/typescript.vim
@@ -78,12 +78,13 @@ syntax match jsxEntityPunct contained "[&.;]"
 syntax match jsxTagName
     \ +<\_s*\zs[^/!?<>"']\++
     \ contained
+    \ nextgroup=jsxAttrib
     \ display
 
 " <tag key={this.props.key}>
 "      ~~~
 syntax match jsxAttrib
-    \ +\(\(<\_s*\)\@<!\_s\)\@<=\<[a-zA-Z_][-0-9a-zA-Z_]*\>\(\_s\+\|\_s*[=/>]\)\@=+
+    \ +\_s\<[a-zA-Z_][-0-9a-zA-Z_]*\>\(\_s\+\|\_s*[=/>]\)\@=+
     \ contained
     \ display
 


### PR DESCRIPTION
I felt it was slow when I scrolled in a file containing a long JSX tag. 
For investigation, I scrolled [my JSX file](https://github.com/tofu-ninjin/tofu-ninjin/blob/afb80ed178a8a6894fe51fe952dd9678f82949e2/src/templates/episode.js) from top to bottom and profile it with `:syntime`. Here is the result of Top 10.
```
:syntime report
  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN
  4.540147   3752   2014    0.007600    0.001210  jsxAttrib          \(\(<\_s*\)\@<!\_s\)\@<=\<[a-zA-Z_][-0-9a-zA-Z_]*\>\(\_s\+\|\_s*[=/>]\)\@=
  0.370877   5586   2374    0.000527    0.000066  jsxRegion          \(\((\|{\|}\|\[\|,\|&&\|||\|?\|:\|=\|=>\|\Wreturn\|^return\|\Wdefault\|^\|>\)\_s*\)\@<=<\_s*\z([_\$a-zA-Z]\(\.\?[\$0-9a-zA-Z]\+\)*\)
  0.152818   220    220     0.002454    0.000695  jsClassDefinition  \(\<extends\>\s\+\)\@<!{\@=
  0.103348   2912   625     0.000282    0.000035  jsRegexpString     \%(\%(\<return\|\<typeof\|\_[^)\]'"[:blank:][:alnum:]_$]\)\s*\)\@<=/\ze[^*/]
  0.062272   2666   81      0.000392    0.000023  graphqlTaggedTemplate \%(gql\|graphql\|Relay.QL\)\ze`
  0.059466   3616   1004    0.000128    0.000016  jsFuncCall         \<\K\k*\ze\s*(
  0.055258   2643   285     0.000139    0.000021  jsxTag             \(/>\)\@=
  0.054946   2668   0       0.000176    0.000021  jsArrowFuncArgs    \<\K\k*\ze\s*=>
  0.045418   2612   27      0.000137    0.000017  jsTaggedTemplate   \<\K\k*\ze`
  0.038391   2117   173     0.000144    0.000018  jsBlockLabel       \<\K\k*\s*::\@!
```

From this result, it can be inferred that the processing of `jsxAttrib` is slow. So I improved the pattern of `jsxAttrib`.
As a result of changing using `nextgroup`, it became as follows.

```
:syntime report
  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN
  0.370325   5481   2350    0.000761    0.000068  jsxRegion          \(\((\|{\|}\|\[\|,\|&&\|||\|?\|:\|=\|=>\|\Wreturn\|^return\|\Wdefault\|^\|>\)\_s*\)\@<=<\_s*\z([_\$a-zA-Z]\(\.\?[\$0-9a-zA-Z]\+\)*\)
  0.198451   216    216     0.002784    0.000919  jsClassDefinition  \(\<extends\>\s\+\)\@<!{\@=
  0.103581   2831   617     0.000338    0.000037  jsRegexpString     \%(\%(\<return\|\<typeof\|\_[^)\]'"[:blank:][:alnum:]_$]\)\s*\)\@<=/\ze[^*/]
  0.064141   2589   81      0.000201    0.000025  graphqlTaggedTemplate \%(gql\|graphql\|Relay.QL\)\ze`
  0.060442   3525   990     0.000185    0.000017  jsFuncCall         \<\K\k*\ze\s*(
  0.055594   2590   0       0.000237    0.000021  jsArrowFuncArgs    \<\K\k*\ze\s*=>
  0.054037   2528   282     0.000444    0.000021  jsxTag             \(/>\)\@=
  0.045480   2535   27      0.000126    0.000018  jsTaggedTemplate   \<\K\k*\ze`
  0.041036   2045   171     0.000160    0.000020  jsBlockLabel       \<\K\k*\s*::\@!
  0.040797   3450   962     0.000136    0.000012  jsString           \z(["']\)
```

Before
![aug-02-2018 01-23-34](https://user-images.githubusercontent.com/16757772/43534641-da3d564c-95f2-11e8-8204-c78534856a17.gif)

After
![aug-02-2018 01-23-56](https://user-images.githubusercontent.com/16757772/43534755-1c8a0fea-95f3-11e8-9707-2c8e96d53a86.gif)

