### PR TITLE
Fix incorrect indent with parenthesis in jsx

### DIFF
--- a/after/indent/javascript.vim
+++ b/after/indent/javascript.vim
@@ -137,7 +137,7 @@ function! GetJsxIndent()
     "   <div>  |   <div>
     "   </div> |   </div>
     " ##);     | ); <--
-    if getline(v:lnum) =~? ');\?' && s:syn_jsx_close_tag(prevsyn)
+    if getline(v:lnum) =~? '^\_s*);\?' && s:syn_jsx_close_tag(prevsyn)
       let ind = ind - s:sw()
     endif
 


### PR DESCRIPTION
This should fix #24 

The parentheses in jsx content were matched by the `);\?` regexp. We should add some specific limitations to avoid this.

BTW, I think this code is no longer needed, as it works well when I deleted it.

```vim
if getline(v:lnum) =~? ');\?' && s:syn_jsx_close_tag(prevsyn)
  let ind = ind - s:sw()
endif
```