### PR TITLE
Fix incorrect highlighting when a tag follows some plain text

### DIFF
--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -48,7 +48,7 @@ syntax match jsxTag
 " <tag/>
 " s~~~~e
 " A big start regexp borrowed from https://git.io/vDyxc
-syntax region jsxReg
+syntax region jsxRegion
       \ start=+\(\((\|{\|}\|\[\|,\|&&\|||\|?\|:\|=\|=>\|\Wreturn\|^return\|\Wdefault\|^\|>\|<[^/]*>\_s*.\+\)\_s*\)\@<=<\_s*\(>\|\z([_\$a-zA-Z]\(\.\?[\$0-9a-zA-Z]\+\)*\)\)+
       \ skip=+<!--\_.\{-}-->+
       \ end=+</\_s*\z1>+

--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -45,7 +45,7 @@ syntax region jsxTag
 " s~~~~e
 " A big start regexp borrowed from https://git.io/vDyxc
 syntax region jsxRegion
-      \ start=+\(\((\|{\|}\|\[\|,\|&&\|||\|?\|:\|=\|=>\|\Wreturn\|^return\|\Wdefault\|^\|>\)\_s*\)\@<=<\_s*\z([_\$a-zA-Z]\(\.\?[\$0-9a-zA-Z]\+\)*\)+
+      \ start=+\(\((\|{\|}\|\[\|,\|&&\|||\|?\|:\|=\|=>\|\Wreturn\|^return\|\Wdefault\|^\|>\|<[^/]*>\_s*.\+\)\_s*\)\@<=<\_s*\z([_\$a-zA-Z]\(\.\?[\$0-9a-zA-Z]\+\)*\)+
       \ skip=+<!--\_.\{-}-->+
       \ end=+</\_s*\z1>+
       \ end=+/>+

--- a/after/syntax/typescript.vim
+++ b/after/syntax/typescript.vim
@@ -45,7 +45,7 @@ syntax region jsxTag
 " s~~~~e
 " A big start regexp borrowed from https://git.io/vDyxc
 syntax region jsxRegion
-      \ start=+\(\((\|{\|}\|\[\|,\|&&\|||\|?\|:\|=\|=>\|\Wreturn\|^return\|\Wdefault\|^\|>\)\_s*\)\@<=<\_s*\z([_\$a-zA-Z]\(\.\?[\$0-9a-zA-Z]\+\)*\)+
+      \ start=+\(\((\|{\|}\|\[\|,\|&&\|||\|?\|:\|=\|=>\|\Wreturn\|^return\|\Wdefault\|^\|>\|<[^/]*>\_s*.\+\)\_s*\)\@<=<\_s*\z([_\$a-zA-Z]\(\.\?[\$0-9a-zA-Z]\+\)*\)+
       \ skip=+<!--\_.\{-}-->+
       \ end=+</\_s*\z1>+
       \ end=+/>+

--- a/after/syntax/typescript.vim
+++ b/after/syntax/typescript.vim
@@ -45,7 +45,7 @@ syntax region jsxTag
 " s~~~~e
 " A big start regexp borrowed from https://git.io/vDyxc
 syntax region jsxRegion
-      \ start=+\(\((\|{\|}\|\[\|,\|&&\|||\|?\|:\|=\|=>\|\Wreturn\|^return\|\Wdefault\|^\|>\|<[^/]*>\_s*.\+\)\_s*\)\@<=<\_s*\z([_\$a-zA-Z]\(\.\?[\$0-9a-zA-Z]\+\)*\)+
+      \ start=+\(\((\|{\|}\|\[\|,\|&&\|||\|?\|:\|=\|=>\|\Wreturn\|^return\|\Wdefault\|^\|>\|<[^/]*>\_s*.\+\)\_s*\)\@<=<\_s*\(>\|\z([_\$a-zA-Z]\(\.\?[\$0-9a-zA-Z]\+\)*\)\)+
       \ skip=+<!--\_.\{-}-->+
       \ end=+</\_s*\z1>+
       \ end=+/>+

--- a/sample.js
+++ b/sample.js
@@ -142,4 +142,12 @@ const SearchBar = ({
   console.log(a);
 }
 
+function tagFollowsPlainText() {
+  return (
+    <div>
+      plain text<br />
+    </div>
+  );
+}
+
 export default Hoge;


### PR DESCRIPTION
I found that when a tag (no matter self-closing or not) appears after a plain text, then the syntax breaks.

![image](https://user-images.githubusercontent.com/3297602/48071988-8565cf80-e216-11e8-9cd7-e1c07f8cfb75.png)
![image](https://user-images.githubusercontent.com/3297602/48072040-a9c1ac00-e216-11e8-825c-0e5ab4f99883.png)

So, I added a new jsx region start scenario. This should fix #25. 