### PR TITLE
Improve syntax group and highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ let g:vim_jsx_pretty_colorful_config = 1 " default 0
 |jsxString| `<tag id="sample">`<br />`________~~~~~~~~_`|
 |jsxCloseTag| `</tag> ｜ <tag />`<br />`~~~~~~ ｜  _____~~` |
 |jsxComponentName| `<Capitals>`<br />`_~~~~~~~~_` |
+|jsxDot| `<Parent.Child>`<br />`_______~______` |
 
 Inspiration
 ---

--- a/autoload/jsx_pretty.vim
+++ b/autoload/jsx_pretty.vim
@@ -12,7 +12,7 @@ function! jsx_pretty#common()
         \ end=+/\@<!>+
         \ end=+\(/>\)\@=+
         \ contained
-        \ contains=jsxTag,jsxError,jsxTagName,jsxAttrib,jsxEqual,jsxString,jsxEscapeJs,
+        \ contains=jsxTag,jsxError,jsxStartTag,jsxAttrib,jsxEqual,jsxString,jsxEscapeJs,
                   \jsxCloseString,jsComment,typescriptLineComment,typescriptComment,
         \ keepend
         \ extend
@@ -45,6 +45,7 @@ function! jsx_pretty#common()
 
   syntax match jsxEntity "&[^; \t]*;" contains=jsxEntityPunct
   syntax match jsxEntityPunct contained "[&.;]"
+  syntax match jsxDot +\.+ contained display
 
   " <MyComponent ...>
   "  ~~~~~~~~~~~
@@ -52,32 +53,27 @@ function! jsx_pretty#common()
   "  <someCamel ...>
   "       ~~~~~
   syntax match jsxComponentName
-        \ +<[A-Z][a-zA-Z0-9]\++hs=s+1
-        \ contained
-        \ display
-  syntax match jsxComponentName
-        \ +</[A-Z][a-zA-Z0-9]\++hs=s+2
+        \ +\<[A-Z][a-zA-Z0-9\$]\+\>+
         \ contained
         \ display
 
   " <tag key={this.props.key}>
   "  ~~~
   syntax match jsxTagName
-        \ +<\s*[-a-zA-Z0-9]\++hs=s+1
+        \ +[-a-zA-Z0-9_\.\$]\++
         \ contained
-        \ contains=jsxComponentName
-        \ nextgroup=jsxAttrib
+        \ contains=jsxComponentName,jsxDot
         \ display
 
-  " </tag>
-  "   ~~~
-  syntax match jsxTagName
-        \ +</\s*[-a-zA-Z0-9]\++hs=s+2
+  " <tag key={this.props.key}>
+  " ~~~~
+  syntax match jsxStartTag
+        \ +\(<\_s*\)\@<=[-a-zA-Z0-9_\.\$]\++
         \ contained
-        \ contains=jsxComponentName
+        \ contains=jsxTagName
         \ nextgroup=jsxAttrib
         \ display
-
+    
   " </tag>
   " ~~~~~~
   syntax match jsxCloseTag
@@ -103,7 +99,7 @@ function! jsx_pretty#common()
 
   " <tag id="sample">
   "        ~
-  syntax match jsxEqual +=+ display
+  syntax match jsxEqual +=+ contained display
 
   " <tag id="sample">
   "         s~~~~~~e
@@ -119,15 +115,17 @@ function! jsx_pretty#common()
   let s:vim_jsx_pretty_enable_jsx_highlight = get(g:, 'vim_jsx_pretty_enable_jsx_highlight', 1)
 
   if s:vim_jsx_pretty_enable_jsx_highlight == 1
-    highlight def link jsxTag Function
-    highlight def link jsxTagName Function
-    highlight def link jsxComponentName Identifier
+    highlight def link jsxTag Comment
+    highlight def link jsxCloseTag jsxTag
+    highlight def link jsxCloseString jsxCloseTag
+    highlight def link jsxTagName Identifier
+    highlight def link jsxComponentName Function
+    highlight def link jsxAttrib Type
+    highlight def link jsxEqual Operator
+    highlight def link jsxDot Operator
     highlight def link jsxString String
     highlight def link jsxComment Error
-    highlight def link jsxAttrib Type
     highlight def link jsxEscapeJs jsxEscapeJs
-    highlight def link jsxCloseTag Identifier
-    highlight def link jsxCloseString jsxCloseTag
   endif
 
   let s:vim_jsx_pretty_colorful_config = get(g:, 'vim_jsx_pretty_colorful_config', 0)

--- a/autoload/jsx_pretty.vim
+++ b/autoload/jsx_pretty.vim
@@ -12,7 +12,7 @@ function! jsx_pretty#common()
         \ end=+/\@<!>+
         \ end=+\(/>\)\@=+
         \ contained
-        \ contains=jsxTag,jsxError,jsxStartTag,jsxAttrib,jsxEqual,jsxString,jsxEscapeJs,
+        \ contains=jsxTag,jsxError,jsxOpenTag,jsxAttrib,jsxEqual,jsxString,jsxEscapeJs,
                   \jsxCloseString,jsComment,typescriptLineComment,typescriptComment,
         \ keepend
         \ extend
@@ -67,7 +67,7 @@ function! jsx_pretty#common()
 
   " <tag key={this.props.key}>
   " ~~~~
-  syntax match jsxStartTag
+  syntax match jsxOpenTag
         \ +\(<\_s*\)\@<=[-a-zA-Z0-9_\.\$]\++
         \ contained
         \ contains=jsxTagName

--- a/sample.js
+++ b/sample.js
@@ -84,19 +84,21 @@ class Hoge extends React.Component {
 
   render() {
     return (
-      <div className="aaa, aaaa">
-        <div className="aaa, aaaa, aaaaaa">
+      <>
+        <div className="aaa, aaaa">
+          <div className="aaa, aaaa, aaaaaa">
 
+          </div>
         </div>
-      </div>
 
-      <div>
-        {(hoge => {
-          if (hoge) {
-            return <div foo-bar foo/>;
-          }
-        })()}
-      </div>
+        <div>
+          {(hoge => {
+            if (hoge) {
+              return <div foo-bar foo/>;
+            }
+          })()}
+        </div>
+      </>
     );
   }
 }
@@ -123,13 +125,13 @@ ReactDOM.render(
     <div></div>
     <div></div>
   </div>,
-  document.getElementById('body');
+  document.getElementById('body')
 )
 
 const hoge = () => {
   ReactDOM.render(
     <div></div>,
-    document.getElementById('body');
+    document.getElementById('body')
   );
 }
 
@@ -168,7 +170,9 @@ class Test extends React.Component {
         horizontal={false}
         renderItem={({ item }) => (
           <View>
-            {item.icon}
+            <View.Icon>
+              {item.icon}
+            </View.Icon>
           </View>
         )}
       />


### PR DESCRIPTION
Based on PR #37 , I did some improvement on it. 

- The syntax group is more reasonable now. 
- The `<, >, </,  />` in the tag are dimmed because of the `Comment` highlight group. It looks much better, I think.
- Added a `jsxDot` group for the dot in `<Parent.Child>`

I tested it on some color schemes, it works well.