### PR TITLE
Refactor the syntax file with many improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,12 @@ let g:vim_jsx_pretty_colorful_config = 1 " default 0
 |jsxAttrib| `<tag id="sample">`<br />`_____~~__________`|
 |jsxEqual| `<tag id="sample">`<br />`_______~_________`|
 |jsxString| `<tag id="sample">`<br />`________~~~~~~~~_`|
-|jsxCloseTag| `</tag> ｜ <tag />`<br />`~~~~~~ ｜  _____~~` |
+|jsxCloseTag| `</tag>`<br />`~~~~~~` |
+|jsxCloseString| `<tag />`<br />`_____~~` |
 |jsxComponentName| `<Capitals>`<br />`_~~~~~~~~_` |
 |jsxDot| `<Parent.Child>`<br />`_______~______` |
+|jsxNamespace| `<foo:bar>`<br />`____~____` |
+|jsxPunct| `<tag></tag>`<br />`~___~~~___~` |
 
 Inspiration
 ---

--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -3,7 +3,6 @@
 "
 " Language: javascript.jsx
 " Maintainer: MaxMellon <maxmellon1994@gmail.com>
-" Depends: pangloss/vim-javascript
 "
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
@@ -21,24 +20,45 @@ if exists('s:current_syntax')
   let b:current_syntax = s:current_syntax
 endif
 
-" <tag key={this.props.key}>
-"          s~~~~~~~~~~~~~~e
-syntax region jsxEscapeJs
-      \ contained
-      \ contains=jsBlock
-      \ start=+{+
-      \ end=++
-      \ extend
+" check the javascript syntax file and cache it
+if !exists('s:js_syntax')
+  let syntax_list = execute('syntax list')
+  if syntax_list =~ "jsNoise"   " pangloss/vim-javascript
+    let s:js_syntax = "vim-javascript"
+  elseif syntax_list =~ "javascriptOpSymbols"   " othree/yajs.vim
+    let s:js_syntax = "yajs"
+  else  " build-in javascript syntax
+    let s:js_syntax = "buildin"
+  endif
+endif
+
+if s:js_syntax == "vim-javascript"   " pangloss/vim-javascript
+  syntax cluster jsExpression add=jsxRegion
+elseif s:js_syntax == "yajs"   " othree/yajs.vim
+  " refine the javascript line comment
+  syntax region javascriptLineComment start=+//+ end=/$/ contains=@Spell,javascriptCommentTodo extend keepend
+  syntax cluster javascriptValue add=jsxRegion
+  syntax cluster javascriptNoReserved add=jsxElement
+else    " build-in javascript syntax
+  " refine the javascript line comment
+  syntax region javaScriptLineComment start=+//+ end=/$/ contains=@Spell,javascriptCommentTodo extend keepend
+  " add a javaScriptBlock group for build-in syntax
+  syntax region javaScriptBlockBuildIn
+        \ contained
+        \ matchgroup=javaScriptBraces
+        \ start="{"
+        \ end="}"
+        \ extend
+        \ contains=javaScriptBlockBuildIn,@javaScriptEmbededExpr,javaScript.*
+        \ fold
+  syntax cluster javaScriptEmbededExpr add=jsxRegion
+endif
 
 " because this is autoloaded, when developing you're going to need to source
 " the autoload/jsx_pretty.vim file manually, or restart vim
 call jsx_pretty#common()
 
-syntax cluster jsExpression add=jsxRegion
-syntax cluster javascriptNoReserved add=jsxRegion
-
 let b:current_syntax = 'javascript.jsx'
 
 let &cpo = s:jsx_cpo
 unlet s:jsx_cpo
-

--- a/after/syntax/typescript.vim
+++ b/after/syntax/typescript.vim
@@ -21,33 +21,26 @@ if exists('s:current_syntax')
   let b:current_syntax = s:current_syntax
 endif
 
-" this is commented out in leafgarland/typescript-vim
-syntax region typescriptFuncBlock
+" refine the typescript line comment
+syntax region typescriptLineComment start=+//+ end=/$/ contains=@Spell,typescriptCommentTodo,typescriptRef extend keepend
+
+" add a typescriptBlock group for typescript
+syntax region typescriptBlock
       \ contained
-      \ matchgroup=typescriptFuncBlock
+      \ matchgroup=typescriptFuncBlockBraces
       \ start="{"
       \ end="}"
-      \ contains=@typescriptAll,typescriptParensErrA,typescriptParensErrB,typescriptParen,typescriptBracket,typescriptBlock,jsxRegion
-      \ fold
-
-" <tag key={this.props.key}>
-"          s~~~~~~~~~~~~~~e
-syntax region jsxEscapeJs
-      \ contained
-      \ contains=typescriptFuncBlock
-      \ start=+{+
-      \ end=++
       \ extend
+      \ contains=@typescriptAll,@typescriptExpression,typescriptBlock
+      \ fold
 
 " because this is autoloaded, when developing you're going to need to source
 " the autoload/jsx_pretty.vim file manually, or restart vim
 call jsx_pretty#common()
 
-syntax cluster typescriptParens add=jsxRegion
-
+syntax cluster typescriptExpression add=jsxRegion
 
 let b:current_syntax = 'typescript.tsx'
 
 let &cpo = s:jsx_cpo
 unlet s:jsx_cpo
-

--- a/after/syntax/typescript.vim
+++ b/after/syntax/typescript.vim
@@ -27,7 +27,7 @@ syntax region typescriptLineComment start=+//+ end=/$/ contains=@Spell,typescrip
 " add a typescriptBlock group for typescript
 syntax region typescriptBlock
       \ contained
-      \ matchgroup=typescriptFuncBlockBraces
+      \ matchgroup=typescriptBraces
       \ start="{"
       \ end="}"
       \ extend

--- a/autoload/jsx_pretty.vim
+++ b/autoload/jsx_pretty.vim
@@ -97,7 +97,7 @@ function! jsx_pretty#common()
   " <tag key={this.props.key}>
   "      ~~~
   syntax match jsxAttrib
-        \ +\<[-A-Za-z_][-:_\.\$0-9A-Za-z]*\>+
+        \ +\<[-A-Za-z_][-:_\$0-9A-Za-z]*\>+
         \ contained
         \ nextgroup=jsxEqual
         \ skipwhite

--- a/sample.js
+++ b/sample.js
@@ -18,6 +18,11 @@ class App extends Component {
     var e = a>c
     var bar = arr[1] < foo;
 
+    if (foo
+      < arr) {
+
+    }
+
     if (a<b && a<d || a>c){
       return <a></a>
     }
@@ -45,7 +50,7 @@ class Hoge extends React.Component {
 
   hoge() {
     Hoge.poge(
-      <div disabled>
+      <div disabled >
         <div></div>
         {this.hoge}
         <div></div>
@@ -57,7 +62,7 @@ class Hoge extends React.Component {
     return (
       <div
         foo={
-          <bar foo='aaa' >
+          <bar foo = 'aaa' >
             <div
               hoge={
                 <div
@@ -101,6 +106,16 @@ class Hoge extends React.Component {
       </>
     );
   }
+}
+
+function test2() {
+	return (
+          <div
+            foo="bar"
+          >
+            <div>child</div>
+          </div>
+	);
 }
 
 export const Hoge = () => (

--- a/test.js
+++ b/test.js
@@ -1,0 +1,166 @@
+import React from 'react';
+
+function test() {
+  const a = 1;
+  let foo;
+  foo = (<div key={1}>after parenthesis</div>);
+  foo = [<div key={1}>after bracket</div>, <div key={2}>after ,</div>];
+  foo = [
+    <div key={1}>after bracket</div>,
+    <div key={2}>after ,</div>
+  ];
+  // corner case
+  foo = (
+
+    <div>
+      {<div>after open brace</div>}
+      <div>after close brace</div>
+      <div>
+        <div>test nested</div>
+      </div>
+    </div>
+  );
+
+  foo = a > 0 ? <div>after ?</div> : <div>after :</div>;
+  foo = <div>after =</div>;
+  foo = a + <div>after +</div>;
+  foo = a - <div>after -</div>;
+  foo = a * <div>after *</div>;
+  foo = a / <div>after /</div>;
+  foo = a && <div>after &&</div>;
+  foo = a || <div>after ||</div>;
+  foo = [].map(x => <div key={x}>after arrow function</div>);
+
+  foo = a > <div>after greater than</div>;
+  foo = a < <div>after less than</div>;
+  // return <div></div>
+  // corner case
+  if (a
+    < 0) {
+    a = b
+  }
+
+  // corner case
+  var a = a
+    < b / a ? b : a;
+
+  // correct
+  foo = <br />
+
+  // corner case
+  if (a
+    < foo
+  ) {
+    a = b
+  }
+
+  foo = <>fragment</>;
+  foo = <div>[<div>fragment</div>]</div>;
+  foo = <foo.bar>support membership element</foo.bar>;
+  foo = <xml:svg>support namespace element</xml:svg>;
+
+  async function testAwait() {
+    await <div>after await</div>;
+  }
+
+  function *testYield() {
+    yield <div>after yield</div>;
+  }
+
+  if (foo ||
+    <div></div>
+  ) {
+    foo = <bar />
+  }
+
+  // should not match this
+  foo = 1 <a
+  foo = foo>a
+  foo = <div>hello, world</div>
+  var c = a < foo
+
+  return <div>
+    plain text<br />plain text<br />
+    plain text<br /><div >plain text</div>some text <br />
+    plain text<div>after plain text</div>
+    {foo ? <div>after question mark</div> : <div>after colon</div>}plain text<div>after plain text</div>
+    <div><div>after element</div></div>
+  </div>;
+}
+
+function test2() {
+  return (
+    <>
+      < div foo="foo, bar">
+        <div className="aaa, aaaa, aaaaaa">text</div>
+        <div>{[1, 2].map(x => <span>{ x / 2 }</span>)}</div>
+      </div>
+
+      <div foo>
+        {(hoge => {
+          if (hoge) {
+            return <div foo-bar foo/>;
+          }
+        })()}
+      </div>
+    </>
+  );
+}
+
+function tagFollowsPlainText() {
+  return (
+    <div>
+      plain text<br />
+      <Input type="checkbox" /> Option 1 <br />
+      <Input type="checkbox" /> Option 2 <br />
+      <Input type="checkbox" /> Option 3 <br />
+      <Input type="checkbox" /> Option 4 <br />
+    </div>
+  );
+}
+
+function testComment() {
+  return <div>
+    <div
+      hoge
+      hoge="string"
+      hoge={foo > 0 ? 'foo' : 'bar'} // inline comment
+      hoge={aaa} /* multiline comment */
+      hoge=<div>valid</div> // according to the jsx spec, this is equal to {<div></div>}
+      hoge=<br /> // this is equal to {<br />}
+      {...this.props}
+    >
+      {...testComment()}
+    </div>
+    <div
+      hoge={aaa}
+      hoge={aaa}
+    />
+    {foo && <div>foo</div>}
+    {(function () {
+      return <div>nested</div>
+    })()}
+  </div>;
+}
+
+function testComponentName() {
+  // shouldn't get a jsxComponentName on just Line here
+  let x = <flatLine />
+    return (
+      <FlatList
+        style={{display: 'none', fontSize: 100}}
+        data={[{ key: "test", icon: <Icon style={APPICON} icon="test" /> }]}
+        numColumns={4}
+        horizontal={false}
+        renderItem={({ item }) => (
+          <View>
+            <View.Icon>
+              {item.icon}
+            </View.Icon>
+          </View>
+        )}
+      />
+    )
+}
+
+export default <div>after default</div>;

--- a/test.js
+++ b/test.js
@@ -123,6 +123,7 @@ function testComment() {
   return <div>
     <div
       hoge
+      foo:bar="hello"
       hoge="string"
       hoge={foo > 0 ? 'foo' : 'bar'} // inline comment
       hoge={aaa} /* multiline comment */

--- a/test.tsx
+++ b/test.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+
+function test() {
+  const a = 1;
+  let foo;
+  foo = (<div key={1}>after parenthesis</div>);
+  foo = [<div key={1}>after bracket</div>, <div key={2}>after ,</div>];
+  foo = [
+    <div key={1}>after bracket</div>,
+    <div key={2}>after ,</div>
+  ];
+  // corner case
+  foo = (
+
+    <div>
+      {<div>after open brace</div>}
+      <div>after close brace</div>
+      <div>
+        <div>test nested</div>
+      </div>
+    </div>
+  );
+
+  foo = a > 0 ? <div>after ?</div> : <div>after :</div>;
+  foo = <div>after =</div>;
+  foo = a + <div>after +</div>;
+  foo = a - <div>after -</div>;
+  foo = a * <div>after *</div>;
+  foo = a / <div>after /</div>;
+  foo = a && <div>after &&</div>;
+  foo = a || <div>after ||</div>;
+  foo = [].map(x => <div key={x}>after arrow function</div>);
+
+  foo = a > <div>after greater than</div>;
+  foo = a < <div>after less than</div>;
+  // return <div></div>
+  // corner case
+  if (a
+    < 0) {
+    a = b
+  }
+
+  // corner case
+  var a = a
+    < b / a ? b : a;
+
+  // correct
+  foo = <br />
+
+  // corner case
+  if (a
+    < foo
+  ) {
+    a = b
+  }
+
+  foo = <>fragment</>;
+  foo = <div>[<div>fragment</div>]</div>;
+  foo = <foo.bar>support membership element</foo.bar>;
+  foo = <xml:svg>support namespace element</xml:svg>;
+
+  async function testAwait() {
+    await <div>after await</div>;
+  }
+
+  function *testYield() {
+    yield <div>after yield</div>;
+  }
+
+  if (foo ||
+    <div></div>
+  ) {
+    foo = <bar />
+  }
+
+  // should not match this
+  foo = 1 <a
+  foo = foo>a
+  foo = <div>hello, world</div>
+  var c = a < foo
+
+  return <div>
+    plain text<br />plain text<br />
+    plain text<br /><div >plain text</div>some text <br />
+    plain text<div>after plain text</div>
+    {foo ? <div>after question mark</div> : <div>after colon</div>}plain text<div>after plain text</div>
+    <div><div>after element</div></div>
+  </div>;
+}
+
+function test2() {
+  return (
+    <>
+      < div foo="foo, bar">
+        <div className="aaa, aaaa, aaaaaa">text</div>
+        <div>{[1, 2].map(x => <span>{ x / 2 }</span>)}</div>
+      </div>
+
+      <div foo>
+        {(hoge => {
+          if (hoge) {
+            return <div foo-bar foo/>;
+          }
+        })()}
+      </div>
+    </>
+  );
+}
+
+function tagFollowsPlainText() {
+  return (
+    <div>
+      plain text<br />
+      <Input type="checkbox" /> Option 1 <br />
+      <Input type="checkbox" /> Option 2 <br />
+      <Input type="checkbox" /> Option 3 <br />
+      <Input type="checkbox" /> Option 4 <br />
+    </div>
+  );
+}
+
+function testComment() {
+  return <div>
+    <div
+      hoge
+      hoge="string"
+      hoge={foo > 0 ? 'foo' : 'bar'} // inline comment
+      hoge={aaa} /* multiline comment */
+      hoge=<div>valid</div> // according to the jsx spec, this is equal to {<div></div>}
+      hoge=<br /> // this is equal to {<br />}
+      {...this.props}
+    >
+      {...testComment()}
+    </div>
+    <div
+      hoge={aaa}
+      hoge={aaa}
+    />
+    {foo && <div>foo</div>}
+    {(function () {
+      return <div>nested</div>
+    })()}
+  </div>;
+}
+
+function testComponentName() {
+  // shouldn't get a jsxComponentName on just Line here
+  let x = <flatLine />
+    return (
+      <FlatList
+        style={{display: 'none', fontSize: 100}}
+        data={[{ key: "test", icon: <Icon style={APPICON} icon="test" /> }]}
+        numColumns={4}
+        horizontal={false}
+        renderItem={({ item }) => (
+          <View>
+            <View.Icon>
+              {item.icon}
+            </View.Icon>
+          </View>
+        )}
+      />
+    )
+}
+
+export default <div>after default</div>;

--- a/test.tsx
+++ b/test.tsx
@@ -123,6 +123,7 @@ function testComment() {
   return <div>
     <div
       hoge
+      foo:bar="hello"
       hoge="string"
       hoge={foo > 0 ? 'foo' : 'bar'} // inline comment
       hoge={aaa} /* multiline comment */


### PR DESCRIPTION
- Implements the JSX specification. https://github.com/facebook/jsx
- Syntax highlighting no longer dependents on pangloss/vim-javascript and yajs.vim
- Resolved many corner cases, like mxw/vim-jsx#180
- Refine syntax group definition, added `jsxElement`, `jsxPuct`, `jsxNamespace` group
- Better support TSX
- Added more test cases
- Much more robust than ever