### PR TITLE
Fix slow problem after open several tsx files.

### DIFF
--- a/after/ftplugin/typescript.vim
+++ b/after/ftplugin/typescript.vim
@@ -5,7 +5,3 @@ if exists("loaded_matchit")
 endif
 
 setlocal suffixesadd+=.tsx
-
-" only so other plugins can use &filetype, e.g. for languageId in a language
-" client
-autocmd BufNewFile,BufRead *.tsx set filetype=typescript.tsx


### PR DESCRIPTION
After debugging, I found that the command `autocmd BufNewFile,BufRead *.tsx set filetype=typescript.tsx` located in `after/ftplugin/typescript.vim` file caused the problem. 

I will remove it, as we don't have to do this, because the plugin `leafgarland/typescript-vim` has set the filetype.