### PR TITLE
Add support to JSX syntax inside the tagged template string

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ The React syntax highlighting and indenting plugin for vim. Also supports the ty
 Features
 ---
 
+- Support JSX highlighting and indenting out of the box. No dependencies.
 - Fully implemented the JSX syntax specification. [https://github.com/facebook/jsx](https://github.com/facebook/jsx)
 - Support React syntax highlighting and indenting for JSX and typescript TSX files.
-- No dependencies for JSX highlighting and indenting.
-- Much more [corner test cases](test.js) covered.
+- Support JSX syntax highlighting and indenting inside the [tagged template](https://github.com/developit/htm) string.
+- Many more [corner test cases](test.js) covered.
 - [Reasonable syntax highlight groups](#syntax-group-list), easy for customization.
 
 Demo
@@ -44,6 +45,12 @@ Installation
 ### vim-plug [https://github.com/junegunn/vim-plug](https://github.com/junegunn/vim-plug)
 
 your `~/.vimrc`:
+
+- No dependencies
+
+    ```vim
+    Plug 'maxmellon/vim-jsx-pretty'
+    ```
 
 - with: vim-javascript (**Recommendation**)
 
@@ -98,6 +105,7 @@ Configuration
 
 |name|default|description|
 |---|---|---|
+|`g:vim_jsx_pretty_template_tags`|`['html', 'raw']`|highlight JSX inside the tagged template string, set it to `[]` to disable this feature|
 |`g:vim_jsx_pretty_enable_jsx_highlight`|1|jsx highlight flag|
 |`g:vim_jsx_pretty_colorful_config`|0|colorful config flag|
 

--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -38,7 +38,11 @@ elseif s:js_syntax == "yajs"   " othree/yajs.vim
   " refine the javascript line comment
   syntax region javascriptLineComment start=+//+ end=/$/ contains=@Spell,javascriptCommentTodo extend keepend
   syntax cluster javascriptValue add=jsxRegion
-  syntax cluster javascriptNoReserved add=jsxElement
+  syntax cluster javascriptNoReserved add=jsxElement,jsxTag
+
+  " add support to arrow function which returns a tagged template string, e.g.
+  " () => html`<div></div>`
+  syntax cluster afterArrowFunc add=javascriptTagRef
 else    " build-in javascript syntax
   " refine the javascript line comment
   syntax region javaScriptLineComment start=+//+ end=/$/ contains=@Spell,javascriptCommentTodo extend keepend
@@ -52,6 +56,10 @@ else    " build-in javascript syntax
         \ contains=javaScriptBlockBuildIn,@javaScriptEmbededExpr,javaScript.*
         \ fold
   syntax cluster javaScriptEmbededExpr add=jsxRegion
+
+  " refine the template string syntax
+  syntax region javaScriptStringT start=+`+ skip=+\\\\\|\\`+ end=+`+ contains=javaScriptSpecial,javaScriptEmbed,@htmlPreproc extend
+  syntax region javaScriptEmbed matchgroup=javaScriptEmbedBraces start=+\${+ end=+}+ contained contains=@javaScriptEmbededExpr,javaScript.*
 endif
 
 " because this is autoloaded, when developing you're going to need to source

--- a/test.js
+++ b/test.js
@@ -47,12 +47,12 @@ function test() {
   // correct
   foo = <br />
 
-  // corner case
-  if (a
-    < foo
-  ) {
-    a = b
-  }
+    // TODO corner case
+    if (a
+      < foo
+    ) {
+      a = b
+    }
 
   foo = <>fragment</>;
   foo = <div>[<div>fragment</div>]</div>;
@@ -163,6 +163,30 @@ function testComponentName() {
       )}
     />
   )
+}
+
+function testLitSyntax({ logs = [], ...props }, { show }) {
+  return html`
+    <div class="logs" ...${props}>
+      <button onClick=${() => this.toggle()}>Down</button>
+      <!-- If expanded, render all logs: -->
+      ${show && raw`
+        <section class="logs" ...${props}>
+          <!-- maps and values work just like JSX -->
+          ${logs.map(log => html`
+            <${Log} class="log" ...${log} />
+          `)}
+          <!--
+            multiline
+            comment
+          -->
+          <${Footer} class="footer">
+            footer content
+          <//>
+        </section>
+      `}
+    </div>
+  `;
 }
 
 export default <div>after default</div>;

--- a/test.tsx
+++ b/test.tsx
@@ -47,12 +47,12 @@ function test() {
   // correct
   foo = <br />
 
-  // corner case
-  if (a
-    < foo
-  ) {
-    a = b
-  }
+    // corner case
+    if (a
+      < foo
+    ) {
+      a = b
+    }
 
   foo = <>fragment</>;
   foo = <div>[<div>fragment</div>]</div>;
@@ -147,21 +147,45 @@ function testComment() {
 function testComponentName() {
   // shouldn't get a jsxComponentName on just Line here
   let x = <flatLine />
-    return (
-      <FlatList
-        style={{display: 'none', fontSize: 100}}
-        data={[{ key: "test", icon: <Icon style={APPICON} icon="test" /> }]}
-        numColumns={4}
-        horizontal={false}
-        renderItem={({ item }) => (
-          <View>
-            <View.Icon>
-              {item.icon}
-            </View.Icon>
-          </View>
-        )}
-      />
-    )
+  return (
+    <FlatList
+      style={{display: 'none', fontSize: 100}}
+      data={[{ key: "test", icon: <Icon style={APPICON} icon="test" /> }]}
+      numColumns={4}
+      horizontal={false}
+      renderItem={({ item }) => (
+        <View>
+          <View.Icon>
+            {item.icon}
+          </View.Icon>
+        </View>
+      )}
+    />
+  )
+}
+
+function testLitSyntax({ logs = [], ...props }, { show }) {
+  return html`
+    <div class="logs" ...${props}>
+      <button onClick=${() => this.toggle()}>Down</button>
+      <!-- If expanded, render all logs: -->
+      ${show && raw`
+        <section class="logs" ...${props}>
+          <!-- maps and values work just like JSX -->
+          ${logs.map(log => html`
+            <${Log} class="log" ...${log} />
+          `)}
+          <!--
+            multiline
+            comment
+          -->
+          <${Footer}>
+            footer content
+          <//>
+        </section>
+      `}
+    </div>
+  `;
 }
 
 export default <div>after default</div>;


### PR DESCRIPTION
Effect:

![image](https://user-images.githubusercontent.com/3297602/50434770-9f1fbb00-0919-11e9-9c4a-2c90c96577cd.png)


This feature is enabled by default and can be disabled by setting `let g:vim_jsx_pretty_template_tags = []` in your vimrc.

Read more: https://github.com/developit/htm

