### PR TITLE
Fix highlight broken when comment after tag name

### DIFF
--- a/autoload/jsx_pretty.vim
+++ b/autoload/jsx_pretty.vim
@@ -36,7 +36,7 @@ function! jsx_pretty#common()
 
   " detect jsx region
   syntax region jsxRegion
-        \ start=+\(\(\_[([,?:=+\-*/<>{}]\|&&\|||\|=>\|\<return\|\<default\|\<await\|\<yield\)\_s*\)\@<=<\_s*\(>\|\z(\(script\)\@!\<[_\$A-Za-z][-:_\.\$0-9A-Za-z]*\>\)\(\_s*\([-+*)\]}&|?]\|/\(\_s*>\)\@!\)\)\@!\)+
+        \ start=+\(\(\_[([,?:=+\-*/<>{}]\|&&\|||\|=>\|\<return\|\<default\|\<await\|\<yield\)\_s*\)\@<=<\_s*\(>\|\z(\(script\)\@!\<[_\$A-Za-z][-:_\.\$0-9A-Za-z]*\>\)\(\_s*\([-+*)\]}&|?]\|/\([/*]\|\_s*>\)\@!\)\)\@!\)+
         \ end=++
         \ contains=jsxElement
 

--- a/test.js
+++ b/test.js
@@ -149,7 +149,7 @@ function testComponentName() {
   // shouldn't get a jsxComponentName on just Line here
   let x = <flatLine />
   return (
-    <FlatList
+    <FlatList // inline comment
       style={{display: 'none', fontSize: 100}}
       data={[{ key: "test", icon: <Icon style={APPICON} icon="test" /> }]}
       numColumns={4}

--- a/test.tsx
+++ b/test.tsx
@@ -148,7 +148,7 @@ function testComponentName() {
   // shouldn't get a jsxComponentName on just Line here
   let x = <flatLine />
   return (
-    <FlatList
+    <FlatList // inline comment
       style={{display: 'none', fontSize: 100}}
       data={[{ key: "test", icon: <Icon style={APPICON} icon="test" /> }]}
       numColumns={4}


### PR DESCRIPTION
Test cases:

```js
function test() {
  const baz = a
    < foo / bar ? b : a;

  const foo = <br />;

  return (
    <div // comment
      foo="bar"
    >
    </div>
  );
}

function test() {
  return (
    <div /* comment */
      foo="bar"
    >
    </div>
  );
}
```