### PR TITLE
Refine

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,17 +106,7 @@ Configuration
 |name|default|description|
 |---|---|---|
 |`g:vim_jsx_pretty_template_tags`|`['html', 'raw']`|highlight JSX inside the tagged template string, set it to `[]` to disable this feature|
-|`g:vim_jsx_pretty_enable_jsx_highlight`|1|jsx highlight flag|
 |`g:vim_jsx_pretty_colorful_config`|0|colorful config flag|
-
-
-If you set `g:vim_jsx_pretty_enable_jsx_highlight`, Disable jsx highlight.
-But highlight group is set to jsx syntax. So you should set manual
-highlight setting.
-
-```vim
-let g:vim_jsx_pretty_enable_jsx_highlight = 0 " default 1
-```
 
 Colorful style (**vim-javascript only**)
 

--- a/after/ftplugin/javascript.vim
+++ b/after/ftplugin/javascript.vim
@@ -3,7 +3,6 @@
 "
 " Language: javascript.jsx
 " Maintainer: MaxMEllon <maxmellon1994@gmail.com>
-" Depends: pangloss/vim-javascript
 "
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
@@ -18,7 +17,7 @@ let b:original_commentstring = &l:commentstring
 
 augroup jsx_comment
   autocmd! CursorMoved <buffer>
-  autocmd CursorMoved <buffer> call jsx_comment#update_comment_string(b:original_commentstring)
+  autocmd CursorMoved <buffer> call jsx_pretty#comment#update_commentstring(b:original_commentstring)
 augroup end
 
 setlocal suffixesadd+=.jsx

--- a/after/ftplugin/typescript.vim
+++ b/after/ftplugin/typescript.vim
@@ -8,7 +8,7 @@ let b:original_commentstring = &l:commentstring
 
 augroup jsx_comment
   autocmd! CursorMoved <buffer>
-  autocmd CursorMoved <buffer> call jsx_comment#update_comment_string(b:original_commentstring)
+  autocmd CursorMoved <buffer> call jsx_pretty#comment#update_commentstring(b:original_commentstring)
 augroup end
 
 setlocal suffixesadd+=.tsx

--- a/after/indent/javascript.vim
+++ b/after/indent/javascript.vim
@@ -3,7 +3,6 @@
 "
 " Language: javascript.jsx
 " Maintainer: MaxMellon <maxmellon1994@gmail.com>
-" Depends: pangloss/vim-javascript
 "
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
@@ -11,8 +10,6 @@ if exists('b:did_indent')
   let s:did_indent = b:did_indent
   unlet b:did_indent
 endif
-
-" runtime! indent/xml.vim
 
 let s:keepcpo = &cpo
 set cpo&vim
@@ -25,7 +22,7 @@ setlocal indentexpr=GetJsxIndent()
 setlocal indentkeys=0{,0},0),0],0\,,!^F,o,O,e,*<Return>,<>>,<<>,/
 
 function! GetJsxIndent()
-  return jsx_indent#get(function('GetJavascriptIndent'))
+  return jsx_pretty#indent#get(function('GetJavascriptIndent'))
 endfunction
 
 let &cpo = s:keepcpo

--- a/after/indent/typescript.vim
+++ b/after/indent/typescript.vim
@@ -23,7 +23,7 @@ setlocal indentexpr=GetJsxIndent()
 setlocal indentkeys=0{,0},0),0],0\,,!^F,o,O,e,*<Return>,<>>,<<>,/
 
 function! GetJsxIndent()
-  return jsx_indent#get(function('GetTypescriptIndent'))
+  return jsx_pretty#indent#get(function('GetTypescriptIndent'))
 endfunction
 
 let &cpo = s:keepcpo

--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -63,8 +63,8 @@ else    " build-in javascript syntax
 endif
 
 " because this is autoloaded, when developing you're going to need to source
-" the autoload/jsx_pretty.vim file manually, or restart vim
-call jsx_pretty#common()
+" the autoload/jsx_pretty/*.vim file manually, or restart vim
+call jsx_pretty#syntax#highlight()
 
 let b:current_syntax = 'javascript.jsx'
 

--- a/after/syntax/typescript.vim
+++ b/after/syntax/typescript.vim
@@ -35,8 +35,8 @@ syntax region typescriptBlock
       \ fold
 
 " because this is autoloaded, when developing you're going to need to source
-" the autoload/jsx_pretty.vim file manually, or restart vim
-call jsx_pretty#common()
+" the autoload/jsx_pretty/*.vim file manually, or restart vim
+call jsx_pretty#syntax#highlight()
 
 syntax cluster typescriptExpression add=jsxRegion
 

--- a/autoload/jsx_pretty/comment.vim
+++ b/autoload/jsx_pretty/comment.vim
@@ -1,4 +1,4 @@
-function! jsx_comment#update_comment_string(original)
+function! jsx_pretty#comment#update_commentstring(original)
   let syn_current = s:syn_name(line('.'), col('.'))
   let syn_start = s:syn_name(line('.'), 1)
 

--- a/autoload/jsx_pretty/indent.vim
+++ b/autoload/jsx_pretty/indent.vim
@@ -64,7 +64,7 @@ let s:end_tag = '/\%(\s*[-:_\.\$0-9A-Za-z]*\s*\|/\)>'
 let s:opfirst = '^' . get(g:,'javascript_opfirst',
       \ '\C\%([<>=,.?^%|/&]\|\([-:+]\)\1\@!\|\*\+\|!=\|in\%(stanceof\)\=\>\)')
 
-function! jsx_indent#get(js_indent)
+function! jsx_pretty#indent#get(js_indent)
   let lnum = v:lnum
   let line = substitute(getline(lnum), '^\s*\|\s*$', '', 'g')
   let current_syn = s:syn_sol(lnum)

--- a/autoload/jsx_pretty/syntax.vim
+++ b/autoload/jsx_pretty/syntax.vim
@@ -168,24 +168,21 @@ function! jsx_pretty#syntax#highlight()
     syntax match jsxComment +<!--\_.\{-}-->+ display
   endif
 
-  let s:vim_jsx_pretty_enable_jsx_highlight = get(g:, 'vim_jsx_pretty_enable_jsx_highlight', 1)
 
-  if s:vim_jsx_pretty_enable_jsx_highlight == 1
-    highlight def link jsxTag Function
-    highlight def link jsxTagName Identifier
-    highlight def link jsxComponentName Function
-    highlight def link jsxAttrib Type
-    highlight def link jsxAttribKeyword jsxAttrib
-    highlight def link jsxEqual Operator
-    highlight def link jsxString String
-    highlight def link jsxDot Operator
-    highlight def link jsxNamespace Operator
-    highlight def link jsxCloseString Comment
-    highlight def link jsxPunct jsxCloseString
-    highlight def link jsxCloseTag jsxCloseString
-    highlight def link jsxComment Comment
-    highlight def link jsxSpreadOperator Operator
-  endif
+  highlight def link jsxTag Function
+  highlight def link jsxTagName Identifier
+  highlight def link jsxComponentName Function
+  highlight def link jsxAttrib Type
+  highlight def link jsxAttribKeyword jsxAttrib
+  highlight def link jsxEqual Operator
+  highlight def link jsxString String
+  highlight def link jsxDot Operator
+  highlight def link jsxNamespace Operator
+  highlight def link jsxCloseString Comment
+  highlight def link jsxPunct jsxCloseString
+  highlight def link jsxCloseTag jsxCloseString
+  highlight def link jsxComment Comment
+  highlight def link jsxSpreadOperator Operator
 
   let s:vim_jsx_pretty_colorful_config = get(g:, 'vim_jsx_pretty_colorful_config', 0)
 

--- a/autoload/jsx_pretty/syntax.vim
+++ b/autoload/jsx_pretty/syntax.vim
@@ -1,4 +1,4 @@
-function! jsx_pretty#common()
+function! jsx_pretty#syntax#highlight()
 
   " <tag id="sample">
   " ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- Better code structure
- Remove `vim_jsx_pretty_enable_jsx_highlight` variable, it's not required. Users can custom their color scheme with `highlight! link ...`