### PR TITLE
Fix incorrect indent of close tag when plain text after jsxBraces

### DIFF
--- a/autoload/jsx_pretty/indent.vim
+++ b/autoload/jsx_pretty/indent.vim
@@ -115,6 +115,7 @@ function! jsx_pretty#indent#get(js_indent)
     elseif line =~ '^<\s*' . s:end_tag
       if !s:syn_xmlish(prev_syn_sol) 
         if s:syn_jsx_escapejs(prev_syn_eol)
+              \ || s:syn_jsx_escapejs(prev_syn_sol)
           return prev_ind - s:sw()
         else
           return prev_ind

--- a/test.js
+++ b/test.js
@@ -94,6 +94,7 @@ function test2() {
       <div foo="foo, bar">
         <div className="aaa, aaaa, aaaaaa">text</div>
         <div>{[1, 2].map(x => <span>{ x / 2 }</span>)}</div>
+        {global.name} text
       </div>
 
       <div foo>

--- a/test.tsx
+++ b/test.tsx
@@ -94,6 +94,7 @@ function test2() {
       < div foo="foo, bar">
         <div className="aaa, aaaa, aaaaaa">text</div>
         <div>{[1, 2].map(x => <span>{ x / 2 }</span>)}</div>
+        {global.name} text
       </div>
 
       <div foo>


### PR DESCRIPTION
Test case

```js
function test() {
  return (
    <div>
      {variable} plain text
      </div> // fix incorrect indent
  );
}

```