### PR TITLE
Remove case sensitivity for syntax matching

### DIFF
--- a/autoload/jsx_pretty/comment.vim
+++ b/autoload/jsx_pretty/comment.vim
@@ -3,7 +3,7 @@ function! jsx_pretty#comment#update_commentstring(original)
   let syn_start = s:syn_name(line('.'), 1)
   let save_cursor = getcurpos()
 
-  if syn_start =~ '^jsx'
+  if syn_start =~? '^jsx'
     let line = getline(".")
     let start = len(matchstr(line, '^\s*'))
     let syn_name = s:syn_name(line('.'), start + 1)
@@ -12,7 +12,7 @@ function! jsx_pretty#comment#update_commentstring(original)
       let &l:commentstring = '// %s'
     elseif s:syn_contains(line('.'), col('.'), 'jsxTaggedRegion')
       let &l:commentstring = '<!-- %s -->'
-    elseif syn_name =~ '^jsxAttrib'
+    elseif syn_name =~? '^jsxAttrib'
       let &l:commentstring = '// %s'
     else
       let &l:commentstring = '{/* %s */}'

--- a/autoload/jsx_pretty/indent.vim
+++ b/autoload/jsx_pretty/indent.vim
@@ -33,7 +33,7 @@ function! s:prev_line(lnum)
 endfunction
 
 function! s:syn_attr_jsx(synattr)
-  return a:synattr =~ "^jsx"
+  return a:synattr =~? "^jsx"
 endfunction
 
 function! s:syn_xmlish(syns)
@@ -41,21 +41,21 @@ function! s:syn_xmlish(syns)
 endfunction
 
 function! s:syn_jsx_element(syns)
-  return get(a:syns, -1) =~ 'jsxElement'
+  return get(a:syns, -1) =~? 'jsxElement'
 endfunction
 
 function! s:syn_js_comment(syns)
-  return get(a:syns, -1) =~ 'Comment$'
+  return get(a:syns, -1) =~? 'Comment$'
 endfunction
 
 function! s:syn_jsx_escapejs(syns)
-  return get(a:syns, -1) =~ '\(\(js\(Template\)\?\|javaScript\(Embed\)\?\|typescript\)Braces\|javascriptTemplateSB\|typescriptInterpolationDelimiter\)' &&
-        \ (get(a:syns, -2) =~ 'jsxEscapeJs' ||
-        \ get(a:syns, -3) =~ 'jsxEscapeJs')
+  return get(a:syns, -1) =~? '\(\(js\(Template\)\?\|javaScript\(Embed\)\?\|typescript\)Braces\|javascriptTemplateSB\|typescriptInterpolationDelimiter\)' &&
+        \ (get(a:syns, -2) =~? 'jsxEscapeJs' ||
+        \ get(a:syns, -3) =~? 'jsxEscapeJs')
 endfunction
 
 function! s:syn_jsx_attrib(syns)
-  return len(filter(copy(a:syns), 'v:val =~ "jsxAttrib"'))
+  return len(filter(copy(a:syns), 'v:val =~? "jsxAttrib"'))
 endfunction
 
 let s:start_tag = '<\s*\([-:_\.\$0-9A-Za-z]\+\|>\)'


### PR DESCRIPTION
Vim allows redefining the case of highlight groups through linking - `hi! link typeScriptBraces MyColor` changes `typescriptBraces` to `typeScriptBraces`. `matchgroup` and `syntax match` both ignore case. By removing case-sensitive matching, you can avoid dificult to debug cases of users or colorschemes redefining highlight group names and getting the case wrong.

Real-world case: gruvbox-community/gruvbox#102

That's a fork of gruvbox - note that the original gruvbox repo, which is fairly widely used, is behind on issues right now and will be impacted by this issue until it's fixed here or gruvbox is back up to date.

Disclaimer: please test before merging, I am not sure of all of the side effects of this change having never written a language plugin like this before.