### PR TITLE
Use win{save,rest}view instead of {getcur,set}pos

### DIFF
--- a/autoload/jsx_pretty/comment.vim
+++ b/autoload/jsx_pretty/comment.vim
@@ -1,7 +1,7 @@
 function! jsx_pretty#comment#update_commentstring(original)
   let syn_current = s:syn_name(line('.'), col('.'))
   let syn_start = s:syn_name(line('.'), 1)
-  let save_cursor = getcurpos()
+  let save_view = winsaveview()
 
   if syn_start =~? '^jsx'
     let line = getline(".")
@@ -22,7 +22,7 @@ function! jsx_pretty#comment#update_commentstring(original)
   endif
 
   " Restore the cursor position
-  call setpos('.', save_cursor)
+  call winrestview(save_view)
 endfunction
 
 function! s:syn_name(lnum, cnum)


### PR DESCRIPTION
The *pos functions mess with visual block mode when '> is EOL (normal $)