### PR TITLE
Revert "Use win{save,rest}view instead of {getcur,set}pos"

### DIFF
--- a/autoload/jsx_pretty/comment.vim
+++ b/autoload/jsx_pretty/comment.vim
@@ -1,7 +1,7 @@
 function! jsx_pretty#comment#update_commentstring(original)
   let syn_current = s:syn_name(line('.'), col('.'))
   let syn_start = s:syn_name(line('.'), 1)
-  let save_view = winsaveview()
+  let save_cursor = getcurpos()
 
   if syn_start =~? '^jsx'
     let line = getline(".")
@@ -22,7 +22,7 @@ function! jsx_pretty#comment#update_commentstring(original)
   endif
 
   " Restore the cursor position
-  call winrestview(save_view)
+  call setpos('.', save_cursor)
 endfunction
 
 function! s:syn_name(lnum, cnum)


### PR DESCRIPTION
@qstrahl I currently revert MaxMEllon/vim-jsx-pretty#87 to fix #88 

If there is any better solution, feel free to submit a PR. Thanks a lot.