### PR TITLE
Improve the syntax highlighting for bit operator

### DIFF
--- a/after/syntax/jsx_pretty.vim
+++ b/after/syntax/jsx_pretty.vim
@@ -36,7 +36,7 @@ syntax region jsxElement
 
 " detect jsx region
 syntax region jsxRegion
-      \ start=+\(\(\_[([,?:=+\-*/<>{}]\|&&\|||\|=>\|\<return\|\<default\|\<await\|\<yield\)\_s*\)\@<=<\_s*\(>\|\z(\(script\)\@!\<[_\$A-Za-z][-:_\.\$0-9A-Za-z]*\>\)\(\_s*\([-+*)\]}&|?,]\|/\([/*]\|\_s*>\)\@!\)\)\@!\)+
+      \ start=+\(\(\_[([,?:=+\-*/>{}]\|<\s\+\|&&\|||\|=>\|\<return\|\<default\|\<await\|\<yield\)\_s*\)\@<=<\_s*\(>\|\z(\(script\)\@!\<[_\$A-Za-z][-:_\.\$0-9A-Za-z]*\>\)\(\_s*\([-+*)\]}&|?,]\|/\([/*]\|\_s*>\)\@!\)\)\@!\)+
       \ end=++
       \ contains=jsxElement
 

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 function test() {
   const a = 1;
+  const b = 1 << c;
   let foo;
   foo = (<div key={1}>after parenthesis</div>);
   foo = [<div key={1}>after bracket</div>, <div key={2}>after ,</div>];


### PR DESCRIPTION
Test case:

```js
const a = b << c;
```

Related to #96 