### PR TITLE
Fix syntax highligiting for generic function

### DIFF
--- a/after/syntax/jsx_pretty.vim
+++ b/after/syntax/jsx_pretty.vim
@@ -36,7 +36,7 @@ syntax region jsxElement
 
 " detect jsx region
 syntax region jsxRegion
-      \ start=+\(\(\_[([,?:=+\-*/>{}]\|<\s\+\|&&\|||\|=>\|\<return\|\<default\|\<await\|\<yield\)\_s*\)\@<=<\_s*\(>\|\z(\(script\)\@!\<[_\$A-Za-z][-:_\.\$0-9A-Za-z]*\>\)\(\_s*\([-+*)\]}&|?,]\|/\([/*]\|\_s*>\)\@!\)\)\@!\)+
+      \ start=+\(\(\_[([,?:=+\-*/>{}]\|<\s\+\|&&\|||\|=>\|\<return\|\<default\|\<await\|\<yield\)\_s*\)\@<=<\_s*\(>\|\z(\(script\|T\s*>\s*(\)\@!\<[_\$A-Za-z][-:_\.\$0-9A-Za-z]*\>\)\(\_s*\([-+*)\]}&|?,]\|/\([/*]\|\_s*>\)\@!\)\)\@!\)+
       \ end=++
       \ contains=jsxElement
 

--- a/test.tsx
+++ b/test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+const head = <T>(arr: T[]): T => arr[0]
+
 function test() {
   const a = 1;
   let foo;


### PR DESCRIPTION
Test case:

The generic function use case:
```
const head = <T>(arr: T[]): T => arr[0];
```

This will break the use case like:

```
const title = <T>(This is a title element)</T>;
```

But the latter is less common, I think.