### PR TITLE
Support the new filetypes javascriptreact/typescriptreact

### DIFF
--- a/after/ftplugin/javascriptreact.vim
+++ b/after/ftplugin/javascriptreact.vim
@@ -1,0 +1,1 @@
+source <sfile>:h/javascript.vim

--- a/after/ftplugin/typescriptreact.vim
+++ b/after/ftplugin/typescriptreact.vim
@@ -1,0 +1,1 @@
+source <sfile>:h/typescript.vim

--- a/after/indent/javascriptreact.vim
+++ b/after/indent/javascriptreact.vim
@@ -1,0 +1,1 @@
+source <sfile>:h/javascript.vim

--- a/after/indent/typescriptreact.vim
+++ b/after/indent/typescriptreact.vim
@@ -1,0 +1,1 @@
+source <sfile>:h/typescript.vim

--- a/after/syntax/javascriptreact.vim
+++ b/after/syntax/javascriptreact.vim
@@ -1,0 +1,1 @@
+source <sfile>:h/javascript.vim

--- a/after/syntax/typescriptreact.vim
+++ b/after/syntax/typescriptreact.vim
@@ -1,0 +1,1 @@
+source <sfile>:h/typescript.vim


### PR DESCRIPTION
The new filetypes (`javascriptreact` and `typescriptreact`) have been discussed thoroughly in https://github.com/vim/vim/issues/4830, the decision was made.

I support this decision although I have argued for this, so it's time to support them in vim-jsx-pretty.