### PR TITLE
Fix matchparen problem

### DIFF
--- a/after/syntax/jsx_pretty.vim
+++ b/after/syntax/jsx_pretty.vim
@@ -18,7 +18,7 @@ syntax region jsxTag
       \ matchgroup=NONE
       \ end=+\%(/\_s*>\)\@=+
       \ contained
-      \ contains=jsxOpenTag,jsxAttrib,jsxEscapeJs,jsxSpreadOperator,jsComment,@javascriptComments,javaScriptLineComment,javaScriptComment,typescriptLineComment,typescriptComment
+      \ contains=jsxOpenTag,jsxAttrib,jsxExpressionBlock,jsxSpreadOperator,jsComment,@javascriptComments,javaScriptLineComment,javaScriptComment,typescriptLineComment,typescriptComment
       \ keepend
       \ extend
       \ skipwhite
@@ -37,7 +37,7 @@ syntax region jsxElement
       \ start=+<\_s*\%(>\|\${\|\z(\<[-:._$A-Za-z0-9]\+\>\)\)+
       \ end=+/\_s*>+
       \ end=+<\_s*/\_s*\z1\_s*>+
-      \ contains=jsxElement,jsxTag,jsxEscapeJs,jsxComment,jsxCloseTag,@Spell
+      \ contains=jsxElement,jsxTag,jsxExpressionBlock,jsxComment,jsxCloseTag,@Spell
       \ keepend
       \ extend
       \ contained
@@ -64,7 +64,7 @@ exe 'syntax region jsxOpenTag
 
 " <tag key={this.props.key}>
 "          ~~~~~~~~~~~~~~~~
-syntax region jsxEscapeJs
+syntax region jsxExpressionBlock
       \ matchgroup=jsxBraces
       \ start=+{+
       \ end=+}+
@@ -82,7 +82,7 @@ syntax match jsxNamespace +:+ contained
 
 " <tag id="sample">
 "        ~
-syntax match jsxEqual +=+ contained skipwhite skipempty nextgroup=jsxString,jsxEscapeJs,jsxRegion
+syntax match jsxEqual +=+ contained skipwhite skipempty nextgroup=jsxString,jsxExpressionBlock,jsxRegion
 
 " <tag />
 "      ~~
@@ -152,10 +152,10 @@ if s:enable_tagged_jsx
         \ end=+`+
         \ extend
         \ contained
-        \ contains=jsxElement,jsxEscapeJs
+        \ contains=jsxElement,jsxExpressionBlock
         \ transparent
 
-  syntax region jsxEscapeJs
+  syntax region jsxExpressionBlock
         \ matchgroup=jsxBraces
         \ start=+\${+
         \ end=+}+
@@ -169,14 +169,14 @@ if s:enable_tagged_jsx
         \ matchgroup=NONE
         \ end=+}\@1<=+
         \ contained
-        \ contains=jsxEscapeJs
+        \ contains=jsxExpressionBlock
         \ skipwhite
         \ skipempty
         \ nextgroup=jsxAttrib,jsxSpreadOperator
 
   syntax keyword jsxAttribKeyword class contained
 
-  syntax match jsxSpreadOperator +\.\.\.+ contained nextgroup=jsxEscapeJs skipwhite
+  syntax match jsxSpreadOperator +\.\.\.+ contained nextgroup=jsxExpressionBlock skipwhite
 
   syntax match jsxCloseTag +<//>+ contained
 

--- a/autoload/jsx_pretty/indent.vim
+++ b/autoload/jsx_pretty/indent.vim
@@ -68,9 +68,9 @@ function s:is_jsx_element(syntax)
   return a:syntax =~? 'jsxElement'
 endfunction
 
-" Whether the specified syntax group is the jsxEscapeJs
-function s:is_jsx_escape(syntax)
-  return a:syntax =~? 'jsxEscapeJs'
+" Whether the specified syntax group is the jsxExpressionBlock
+function s:is_jsx_expression(syntax)
+  return a:syntax =~? 'jsxExpressionBlock'
 endfunction
 
 " Whether the specified syntax group is the jsxBraces
@@ -189,7 +189,7 @@ endfunction
 " - jsxRegion
 " - jsxTaggedRegion
 " - jsxElement
-" - jsxEscapeJs
+" - jsxExpressionBlock
 " - Other
 function s:syntax_context(lnum)
   let start_col = s:start_col(a:lnum)
@@ -199,9 +199,9 @@ function s:syntax_context(lnum)
   let i = 0
 
   for syntax_name in reversed
-    " If the current line is jsxEscapeJs and not starts with jsxBraces
-    if s:is_jsx_escape(syntax_name)
-      return 'jsxEscapeJs'
+    " If the current line is jsxExpressionBlock and not starts with jsxBraces
+    if s:is_jsx_expression(syntax_name)
+      return 'jsxExpressionBlock'
     endif
 
     if s:is_jsx_region(syntax_name)
@@ -285,7 +285,7 @@ function! jsx_pretty#indent#get(js_indent)
     endif
 
     return s:jsx_indent_element(v:lnum)
-  elseif syntax_context == 'jsxEscapeJs'
+  elseif syntax_context == 'jsxExpressionBlock'
     let prev_lnum = s:prev_lnum(v:lnum)
     let prev_line = s:trim(getline(prev_lnum))
 

--- a/doc/vim-jsx-pretty-doc.txt
+++ b/doc/vim-jsx-pretty-doc.txt
@@ -62,7 +62,6 @@ highlight setting.
     highlight def link jsxNameSpace Function
     highlight def link jsxComment Error
     highlight def link jsxAttrib Type
-    highlight def link jsxEscapeJs jsxEscapeJs
     highlight def link jsxCloseTag Identifier
     highlight def link jsxCloseString Identifier
 


### PR DESCRIPTION
The `jsxEscapeJs` syntax group is conflict with the reserved syntax group defined in matchparen.vim, so rename it to another group name can resolve this issue.

https://github.com/vim/vim/blob/99ebf22c523e3fdb491b2c92b6f3a7d42721361d/runtime/plugin/matchparen.vim#L114

Related #111 