### PR TITLE
Fix the ambiguity of typescript and jsx syntax

### DIFF
--- a/after/syntax/typescript.vim
+++ b/after/syntax/typescript.vim
@@ -46,9 +46,11 @@ if !hlexists('typescriptTypeCast')
         \ fold
 endif
 
-syntax cluster typescriptExpression add=jsxRegion,typescriptParens
-
 runtime syntax/jsx_pretty.vim
+syntax cluster typescriptExpression add=jsxRegion,typescriptParens,tsCast
+" Fix type casting ambiguity with JSX syntax
+syntax match typescriptTypeBrackets +[<>]+ contained
+syntax match typescriptTypeCast +<\([_$A-Za-z0-9]\+\)>\%(\s*\%([_$A-Za-z0-9]\+\s*;\?\|(\)\%(\_[^<]*</\1>\)\@!\)\@=+ contains=typescriptTypeBrackets,@typescriptType
 
 let b:current_syntax = 'typescript.tsx'
 

--- a/test.tsx
+++ b/test.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 
 const head = <T>(arr: T[]): T => arr[0]
 
+const foo = <string>bar;
+const foo = <string>bar;
+</string>
+
 function test() {
   const a = 1;
   let foo;


### PR DESCRIPTION
Test cases

```tsx
const foo = <string>bar;
const foo = <string>bar;
</string>
```