### PR TITLE
Fix 'commentstring' detection

### DIFF
--- a/after/ftplugin/javascript.vim
+++ b/after/ftplugin/javascript.vim
@@ -21,11 +21,11 @@ if exists("loaded_matchup")
   let b:match_skip = 's:comment\|string'
 endif
 
-let b:original_commentstring = &l:commentstring
+let b:jsx_pretty_old_cms = &l:commentstring
 
 augroup jsx_comment
   autocmd! CursorMoved <buffer>
-  autocmd CursorMoved <buffer> call jsx_pretty#comment#update_commentstring(b:original_commentstring)
+  autocmd CursorMoved <buffer> call jsx_pretty#comment#update_commentstring(b:jsx_pretty_old_cms)
 augroup end
 
 setlocal suffixesadd+=.jsx

--- a/after/ftplugin/tsx.vim
+++ b/after/ftplugin/tsx.vim
@@ -18,11 +18,11 @@ if exists("loaded_matchup")
   let b:match_skip = 's:comment\|string'
 endif
 
-let b:original_commentstring = &l:commentstring
+let b:jsx_pretty_old_cms = &l:commentstring
 
 augroup jsx_comment
   autocmd! CursorMoved <buffer>
-  autocmd CursorMoved <buffer> call jsx_pretty#comment#update_commentstring(b:original_commentstring)
+  autocmd CursorMoved <buffer> call jsx_pretty#comment#update_commentstring(b:jsx_pretty_old_cms)
 augroup end
 
 setlocal suffixesadd+=.tsx

--- a/autoload/jsx_pretty/comment.vim
+++ b/autoload/jsx_pretty/comment.vim
@@ -1,18 +1,18 @@
 function! jsx_pretty#comment#update_commentstring(original)
-  let syn_current = s:syn_name(line('.'), col('.'))
-  let syn_start = s:syn_name(line('.'), 1)
+  let line = getline(".")
+  let col = col('.')
+  if line !~# '^\s*$' && line[: col - 1] =~# '^\s*$'    " skip indent
+    let col = indent('.') + 1
+  endif
+  let syn_start = s:syn_name(line('.'), col)
   let save_cursor = getcurpos()
 
   if syn_start =~? '^jsx'
-    let line = getline(".")
-    let start = len(matchstr(line, '^\s*'))
-    let syn_name = s:syn_name(line('.'), start + 1)
-
     if line =~ '^\s*//'
       let &l:commentstring = '// %s'
-    elseif s:syn_contains(line('.'), col('.'), 'jsxTaggedRegion')
+    elseif s:syn_contains(line('.'), col, 'jsxTaggedRegion')
       let &l:commentstring = '<!-- %s -->'
-    elseif syn_name =~? '^jsxAttrib'
+    elseif syn_start =~? '^jsxAttrib'
       let &l:commentstring = '// %s'
     else
       let &l:commentstring = '{/* %s */}'


### PR DESCRIPTION
via https://github.com/tyru/caw.vim/issues/91

```jsx
const foo = 'this is js style';

const bar = (
    <h1>this is jsx style</h1>
);
```

# Screenshot

![fix-commentstring-auto-detection](https://user-images.githubusercontent.com/48169/76671872-3d11ab00-65dc-11ea-8c23-c55c7a0217f0.gif)