### PR TITLE
Add extend parameter to jsxString

### DIFF
--- a/after/syntax/jsx_pretty.vim
+++ b/after/syntax/jsx_pretty.vim
@@ -136,7 +136,7 @@ exe 'syntax match jsxTagName
 " and
 " <tag id='sample'>
 "         ~~~~~~~~
-syntax region jsxString start=+\z(["']\)+  skip=+\\\\\|\\\z1\|\\\n+  end=+\z1+ contained contains=@Spell
+syntax region jsxString start=+\z(["']\)+  skip=+\\\\\|\\\z1\|\\\n+  end=+\z1+ extend contained contains=@Spell
 
 let s:tags = get(g:, 'vim_jsx_pretty_template_tags', ['html', 'jsx'])
 let s:enable_tagged_jsx = !empty(s:tags)


### PR DESCRIPTION
A jsxString which contained a ">" would close a jsxTag and everything
would then look weird.

This prevents the jsxTag region from ending inside a string.